### PR TITLE
remove bootstrap-slider, use CDN resources for common libraries

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
 
         clean: ["./build"],
         copy: {
-            requirejs: { src: "bower_components/requirejs/require.js", dest: "build/js/require.js" },
+            //paper: { src: "bower_components/paper/dist/paper-full.min.js", dest: "build/js/paper-full.min.js" },
             html: { src: "index-build.html", dest: "build/index.html" },
             images: { expand: true, cwd: "images", src: "**", dest: "build/images/" }
         },
@@ -35,7 +35,6 @@ module.exports = function (grunt) {
                     "build/style.css": [
                         "bower_components/bootstrap/dist/css/bootstrap.min.css",
                         "bower_components/pick-a-color/build/1.2.3/css/pick-a-color-1.2.3.min.css",
-                        "bower_components/bootstrap-slider/css/bootstrap-slider.css",
                         "css/basic.css"
                     ]
                 }
@@ -44,10 +43,16 @@ module.exports = function (grunt) {
         requirejs: {
             compile: {
                 options: {
-                    baseUrl: "js/src/",
                     mainConfigFile: "js/src/main.js",
-                    name: "main",
-                    out: "build/js/main.js",
+                    baseUrl: "js/src/",
+                    paths : {
+                        "jquery" : "empty:",
+                        "backbone" : "empty:",
+                        "underscore" : "empty:",
+                        "handlebars"  : "empty:"
+                    },
+                    name: "app",
+                    out: "build/js/app.js",
                     // optimize: "none",
                     useStrict: true
                 }
@@ -67,7 +72,7 @@ module.exports = function (grunt) {
     grunt.registerTask("test", ["jshint", "jscs"]);
 
     grunt.registerTask("build", [
-        "test", "clean", "copy:requirejs", "copy:html", "copy:images", "cssmin", "requirejs"
+        "test", "clean", "copy:html", "copy:images", "cssmin", "requirejs"
     ]);
 
     grunt.registerTask("default", ["test"]);

--- a/bower.json
+++ b/bower.json
@@ -20,13 +20,12 @@
   ],
   "dependencies": {
     "bootstrap": "3.1.1",
-    "backbone": "~1.1.2",
+    "backbone": "1.1.2",
     "FileSaver": "*",
     "handlebars": "1.3.0",
     "jquery": "2.1.1",
     "paper": "0.9.19",
     "requirejs": "2.1.14",
-    "bootstrap-slider": "git://github.com/seiyria/bootstrap-slider.git",
     "js-toolbox": "git://github.com/jimmydo/js-toolbox.git",
     "underscore": "1.6.0",
     "tinycolor": "0.9.15",
@@ -35,7 +34,7 @@
   },
   "resolutions": {
     "bootstrap": "3.1.1",
-    "backbone": "~1.1.2",
+    "backbone": "1.1.2",
     "jquery": "2.1.1",
     "underscore": "1.6.0"
   }

--- a/index-build.html
+++ b/index-build.html
@@ -132,7 +132,7 @@
                   <div class="form-group">
                     <label for="hidden-input">Stroke Weight</label>
                     <br>
-                    <input id = "strokeSlider" type="text" class="span2" value="" data-slider-min="1" data-slider-max="40" data-slider-step="1" data-slider-value="1" data-slider-orientation="horizontal" data-slider-selection="after">
+                    <input id="strokeSlider" type="range" min="0" max="40">
                   
                     
                     </div>
@@ -197,7 +197,47 @@
    
 
     <!-- main application script -->
-    <script data-main="js/main" src="js/require.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.14/require.min.js"></script>
+    <script>
+      (function () {
+        require.config({
+          
+          baseUrl: "js/",
+
+          paths : {
+              "jquery" : "//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min",
+              "backbone" : "//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.2/backbone-min",
+              "underscore" : "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min",
+              "handlebars": "//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.3.0/handlebars.min",
+              "paper" : "../../bower_components/paper/dist/paper-full",
+              "toolbox": "../../bower_components/js-toolbox/toolbox",
+              "tinycolor": "../../bower_components/tinycolor/tinycolor",
+              "pickacolor": "../../bower_components/pick-a-color/build/1.2.4/js/pick-a-color-1.2.4.min",
+              "filesaver": "../../bower_components/FileSaver/FileSaver"
+          },
+          
+          shim: {
+              "handlebars": {
+                  exports: "Handlebars"
+              },
+
+              "toolbox": {
+                  exports: "Toolbox"
+              },
+                      
+              "pickacolor": {
+                  deps: ["tinycolor", "jquery"],
+                  exports: "Pickacolor"
+              }    
+          }
+
+        });
+
+        require(["jquery", "backbone", "underscore", "handlebars"], function () {
+          require(["app"]);
+        });
+      }());
+    </script>
 
   </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
   <!-- Library CSS -->
   <link href="bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="bower_components/pick-a-color/build/1.2.3/css/pick-a-color-1.2.3.min.css">   
-  <link href="bower_components/bootstrap-slider/css/bootstrap-slider.css" rel="stylesheet">
 
   <!-- Page CSS -->
   <link href="css/basic.css" rel="stylesheet">
@@ -138,9 +137,7 @@
                   <div class="form-group">
                     <label for="hidden-input">Stroke Weight</label>
                     <br>
-                    <input id = "strokeSlider" type="text" class="span2" value="" data-slider-min="1" data-slider-max="40" data-slider-step="1" data-slider-value="1" data-slider-orientation="horizontal" data-slider-selection="after">
-                  
-                    
+                    <input id="strokeSlider" type="range" min="0" max="40">
                     </div>
                      <div class="form-group">
                          <label for="hidden-input">Scaffold</label>

--- a/js/src/app.js
+++ b/js/src/app.js
@@ -1,16 +1,5 @@
-/* Filename: app.js */
-define([
-  'jquery', 
-  'underscore', 
-  'backbone',
-  'router', // Request router.js
-], function($, _, Backbone, Router){
-  var initialize = function(){
-    // Pass in our Router module and call it's initialize function
-    Router.initialize();
-  };
-//checked out on my local machine
-  return { 
-    initialize: initialize
-  };
+define(["jquery", "router"], function ($, Router) {
+    $(function () {
+        Router.initialize();
+    });
 });

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -1,24 +1,19 @@
-/* Filename: main.js */
-
 require.config({
-
-    baseUrl: "js/src",
-
     paths : {
+        // Note: Paths must also be added to index-build.html
+        // CDN paths must be added to the Gruntfile as "empty:"
         "jquery" : "../../bower_components/jquery/dist/jquery",
-        "paper" : "../../bower_components/paper/dist/paper-full",
         "backbone" : "../../bower_components/backbone/backbone",
         "underscore" : "../../bower_components/underscore/underscore",
         "handlebars"  : "../../bower_components/handlebars/handlebars",
+        "paper" : "../../bower_components/paper/dist/paper-full",
         "toolbox": "../../bower_components/js-toolbox/toolbox",
         "tinycolor": "../../bower_components/tinycolor/tinycolor",
         "pickacolor": "../../bower_components/pick-a-color/build/1.2.4/js/pick-a-color-1.2.4.min",
-        "filesaver": "../../bower_components/FileSaver/FileSaver",
-        "slider": "../../bower_components/bootstrap-slider/js/bootstrap-slider"
+        "filesaver": "../../bower_components/FileSaver/FileSaver"
     },
-    
+  
     shim: {
-
         "handlebars": {
             exports: "Handlebars"
         },
@@ -26,15 +21,15 @@ require.config({
         "toolbox": {
             exports: "Toolbox"
         },
-                
+          
         "pickacolor": {
             deps: ["tinycolor", "jquery"],
             exports: "Pickacolor"
         }
-               
     }
+
 });
 
-require(["app"], function (App) {
-    App.initialize();
+require(["jquery", "backbone", "underscore", "handlebars"], function () {
+    require(["app"]);
 });

--- a/js/src/views/drawing/PropertyView.js
+++ b/js/src/views/drawing/PropertyView.js
@@ -9,10 +9,7 @@ define([
   'handlebars',
   'tinycolor',
   'pickacolor',
-  'models/PaperManager',
-  'slider'
-
-
+  'models/PaperManager'
 ], function($, _, Backbone, Handlebars, Tinycolor, Pickacolor,PaperManager) {
 
   var template, source;
@@ -35,9 +32,8 @@ define([
       this.currentPaths = [];
       source = $('#parameterTemplate').html();
       template = Handlebars.compile(source);
-      $('#strokeSlider').slider();
 
-      $('#strokeSlider').on('slide', function(slideEvt) {
+      $('#strokeSlider').on('change', function(slideEvt) {
         $('#strokeSlider').trigger('stroke-change');
       });
 
@@ -83,8 +79,7 @@ define([
     },
 
     strokeChange: function(event) {
-       var value = $(event.target).attr('data').split(" ")[1];
-      value = Number(value.substring(1, value.length - 1));
+       var value = parseInt($(event.target).val(), 10);
       this.model.updateStroke(value);
     },
 
@@ -206,8 +201,8 @@ define([
         $('#stroke').val(stroke.toCSS(true).substr(1));
       }
       if (width) {
-        ////console.log("setting slider");
-        $('#strokeSlider').slider('setValue', width, false);
+        //console.log("setting slider");
+        $('#strokeSlider').val(width);
       }
 
       this.setParams();


### PR DESCRIPTION
remove bootstrap-slider
replace slider with range form element
restructure require.js config to allow for CDN resources
Swap in CDN resources in build for jquery, backbone, underscore, handlebars
