### PR TITLE
Further improve build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,6 @@ module.exports = function (grunt) {
 
         clean: ["./build"],
         copy: {
-            //paper: { src: "bower_components/paper/dist/paper-full.min.js", dest: "build/js/paper-full.min.js" },
             html: { src: "index-build.html", dest: "build/index.html" },
             images: { expand: true, cwd: "images", src: "**", dest: "build/images/" },
             fonts: { expand: true, cwd: "fonts", src: "**", dest: "build/fonts/" }
@@ -40,17 +39,15 @@ module.exports = function (grunt) {
         requirejs: {
             compile: {
                 options: {
-                    mainConfigFile: "js/src/main.js",
+                    paths: { "requirejs" : "../../bower_components/requirejs/require" },
+                    include : "requirejs",
+                    insertRequire : ["app"],
+                    mainConfigFile: "js/src/config.js",
                     baseUrl: "js/src/",
-                    paths : {
-                        "jquery" : "empty:",
-                        "backbone" : "empty:",
-                        "underscore" : "empty:",
-                        "handlebars"  : "empty:"
-                    },
                     name: "app",
-                    out: "build/js/app.js",
+                    out: "build/js/para.js",
                     // optimize: "none",
+                    wrapShim: true,
                     useStrict: true
                 }
             }
@@ -69,7 +66,7 @@ module.exports = function (grunt) {
     grunt.registerTask("test", ["jshint", "jscs"]);
 
     grunt.registerTask("build", [
-        "test", "clean", "copy:html", "copy:images", "copy:fonts", "cssmin", "requirejs"
+        "test", "clean", "copy", "cssmin", "requirejs"
     ]);
 
     grunt.registerTask("default", ["test"]);

--- a/index-build.html
+++ b/index-build.html
@@ -208,49 +208,7 @@
 
 </div>
      <!-- main application script -->
-    <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.14/require.min.js"></script>
-    <script>
-      (function () {
-        require.config({
-          
-          baseUrl: "js/",
-
-          paths : {
-            "jquery" : "//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min",
-            "backbone" : "//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.2/backbone-min",
-            "underscore" : "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min",
-            "handlebars": "//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.3.0/handlebars.min",
-            "paper" : "../../bower_components/paper/dist/paper-full",
-            "toolbox": "../../bower_components/js-toolbox/toolbox",
-            "filesaver": "../../bower_components/FileSaver/FileSaver",
-            "backbone.undo": "../../bower_components/Backbone.Undo/Backbone.Undo",
-            "jquery-ui" : "../../bower_components/jqueryui/jquery-ui",
-            "iris-color-picker": "../../bower_components/iris-color-picker/dist/iris",
-            "jquery-cookie" : "../bower_components/jquery-cookie/jquery.cookie"
-          },
-          
-          shim: {
-            "handlebars": {
-                exports: "Handlebars"
-            },
-
-            "toolbox": {
-                exports: "Toolbox"
-            },
-
-            "iris-color-picker":{
-              deps: ["jquery", "jquery-ui"],
-              exports: "IrisColorPicker"
-            }
-          }
-
-        });
-
-        require(["jquery", "jquery-ui", "backbone", "underscore", "handlebars"], function () {
-          require(["app"]);
-        });
-      }());
-    </script>
-
+    <script src="js/para.js"></script>
+    
   </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -205,13 +205,12 @@
   </section> <!--/save-menu-->
 </div><!--/properties-->
 
- 
-
-
 </div>
 
 <!-- main application script -->
-<script data-main="js/src/main" src="bower_components/requirejs/require.js"></script>
+<script src="bower_components/requirejs/require.js"></script>
+<script src="js/src/config.js"></script>
+<script>require(["app"]);</script>
 
 </body>
 </html>

--- a/js/src/config.js
+++ b/js/src/config.js
@@ -1,11 +1,11 @@
 require.config({
+    baseUrl : "js/src",
+
     paths : {
-        // Note: Paths must also be added to index-build.html
-        // CDN paths must be added to the Gruntfile as "empty:"
         "jquery" : "../../bower_components/jquery/dist/jquery",
         "backbone" : "../../bower_components/backbone/backbone",
         "underscore" : "../../bower_components/underscore/underscore",
-        "handlebars"  : "../../bower_components/handlebars/handlebars",
+        "handlebars"  : "../../bower_components/handlebars/handlebars.amd",
         "paper" : "../../bower_components/paper/dist/paper-full",
         "toolbox": "../../bower_components/js-toolbox/toolbox",
         "filesaver": "../../bower_components/FileSaver/FileSaver",
@@ -15,23 +15,15 @@ require.config({
         "jquery-cookie" : "../bower_components/jquery-cookie/jquery.cookie"
     },
   
-    shim: {
-        "handlebars": {
-            exports: "Handlebars"
-        },
-        
+    shim: {       
         "toolbox": {
             exports: "Toolbox"
         },
-
+        "backbone.undo": {
+            deps: ["backbone"]
+        },
         "iris-color-picker":{
-            deps: ["jquery", "jquery-ui"],
-            exports: "IrisColorPicker"
+            deps: ["jquery", "jquery-ui"]
         }
     }
-
-});
-
-require(["jquery", "jquery-ui", "backbone", "underscore", "handlebars"], function () {
-    require(["app"]);
 });

--- a/js/src/views/drawing/ContextView.js
+++ b/js/src/views/drawing/ContextView.js
@@ -21,7 +21,7 @@ var template,source, menuX, menuY, currentNode;
       this.listenTo(this.event_bus, 'openMenu', this.showMenu);
       this.visible = false;
       source = $('#menu-template').html();
-      template = Handlebars.compile(source);
+      template = Handlebars.default.compile(source);
       
     },
 

--- a/js/src/views/drawing/PropertyView.js
+++ b/js/src/views/drawing/PropertyView.js
@@ -26,7 +26,7 @@ define([
       this.listenTo(this.model, 'selectionReset', this.selectionReset);
       this.currentPaths = [];
       source = $('#parameterTemplate').html();
-      template = Handlebars.compile(source);
+      template = Handlebars.default.compile(source);
 
 
       $('#fillColorBlock').addClass('color-block-selected');


### PR DESCRIPTION
Switch to AMD version of Handlebars
Use one require config file
Add require.js to output build
Throw away CDN madness in build

**Important:** The AMD version of Handlebars is a bit different. It puts the compiler off the `Handlebars.default` object (so calls to the compiler need to look like `Handlebars.default.compile(...)`
