### PR TITLE
Fix issue 122

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "FileSaver": "*",
     "handlebars": "1.3.0",
     "jquery": "2.1.1",
-    "paper": "0.9.19",
+    "paper": "https://github.com/mbc/paper.js.git#fix-unchecked-inversetransform-bugs",
     "requirejs": "2.1.14",
     "js-toolbox": "git://github.com/jimmydo/js-toolbox.git",
     "underscore": "1.6.0",

--- a/js/src/models/data/Instance.js
+++ b/js/src/models/data/Instance.js
@@ -1027,11 +1027,25 @@ define([
 			if (registerUndo) {
 				this.addToUndoStack();
 			}
+
+			var dataClone = null;
+
 			if (data.translationDelta && this.nodeParent) {
+				data = dataClone || (dataClone = _.clone(data));
+
 				var tdelta = data.translationDelta;
 				var ndelta = this.nodeParent.inverseTransformPoint(tdelta);
 				data.translationDelta.x = ndelta.x;
 				data.translationDelta.y = ndelta.y;
+			}
+
+			if (data.hasOwnProperty('scalingDelta') && data.scalingDelta.operator == 'set') {
+				data = dataClone || (dataClone = _.clone(data));
+
+				var xScalingSign = (data.scalingDelta.x < 0.0) ? -1.0 : +1.0;
+				var yScalingSign = (data.scalingDelta.y < 0.0) ? -1.0 : +1.0;
+				data.scalingDelta.x = Math.max(1e-2, Math.min(1e+3, Math.abs(data.scalingDelta.x))) * xScalingSign;
+				data.scalingDelta.y = Math.max(1e-2, Math.min(1e+3, Math.abs(data.scalingDelta.y))) * yScalingSign;
 			}
 
 			for (var prop in data) {
@@ -1047,16 +1061,6 @@ define([
 						p.operator = 'set';
 					}
 					if (p.operator === 'set') {
-						if (prop === 'scalingDelta') {
-							if (data[prop].x && data[prop].x === 0) {
-
-								data[prop].x = 0.01;
-							}
-							if (data[prop].y && data[prop].y === 0) {
-
-								data[prop].y = 0.01;
-							}
-						}
 						console.log('setting value conditional');
 						this.get(prop).setValue(p);
 					} else if (p.operator === 'add') {

--- a/js/src/models/tools/SelectToolModel.js
+++ b/js/src/models/tools/SelectToolModel.js
@@ -247,7 +247,7 @@ define([
         var clickPos = startDist; //position of clicked point, relative to center
         var dragPos = event.point.subtract(posPoint); //position of the point dragged to (relative to center)
         var centerDist = clickPos.length; //distance from center of shape to clicked point
-        const SCALING_FACTOR = 1;
+        const SCALING_THROTTLE = 5.0;
 
         var dragPosProjX = dragPos.project(xAxis);
         var dragPosProjY = dragPos.project(yAxis);
@@ -255,8 +255,8 @@ define([
         var signedX = dragPosProjX.dot(clickPos) > 0.0 ? +1.0 : -1.0;
         var signedY = dragPosProjY.dot(clickPos) > 0.0 ? +1.0 : -1.0;
 
-        var scaleX = dragPosProjX.length / Math.abs(clickPos.dot(xAxis)) * SCALING_FACTOR * signedX;
-        var scaleY = dragPosProjY.length / Math.abs(clickPos.dot(yAxis)) * SCALING_FACTOR * signedY;
+        var scaleX = Math.max(1.0, dragPosProjX.length) / Math.max(SCALING_THROTTLE, Math.abs(clickPos.dot(xAxis))) * signedX;
+        var scaleY = Math.max(1.0, dragPosProjY.length) / Math.max(SCALING_THROTTLE, Math.abs(clickPos.dot(yAxis))) * signedY;
 
 
 


### PR DESCRIPTION
The scaling tool is now much closer to Illustrator's.

Note: one issue - when a dimension collapsed to zero, and, essentially, everything broke - looked like a pair of bugs in paper.js to me. I saw that one of them has been fixed, but not in any official release yet (the other didn't look like it was fixed to me, but it may be handled in a different way). To incorporate these fixes, I forked paper.js and updated the bower dependency. (Of course, it will probably be good to update to the newest version, when it's released, but even v0.9.25 seems to have some breaking changes right now.)